### PR TITLE
Sanitize hex colors by prefixing missing # if necessary

### DIFF
--- a/public/js/lib/models/arrow.js
+++ b/public/js/lib/models/arrow.js
@@ -75,8 +75,8 @@ if (!('CSSArrowPlease' in window)) window.CSSArrowPlease = {};
       css += '\tbackground: ' + color + ';\n';
 
       if (hasBorder) {
-          borderColor = this._sanitizeHexColors(borderColor);
-          css += '\tborder: ' + borderWidth + 'px solid ' + borderColor + ';\n';
+        borderColor = this._sanitizeHexColors(borderColor);
+        css += '\tborder: ' + borderWidth + 'px solid ' + borderColor + ';\n';
       }
 
       css += '}\n';
@@ -217,7 +217,7 @@ if (!('CSSArrowPlease' in window)) window.CSSArrowPlease = {};
     @protected
     **/
     _sanitizeHexColors: function(h) {
-        return (h.charAt(0)==='#')?h:'#' + h;
+      return (h.charAt(0)==='#')?h:'#' + h;
     },
 
     /**


### PR DESCRIPTION
By copy & pasting hex color values from photoshop or gimp it happend that the leading "#" missing in the css view. This patch fixes this issue by prefixing a "#" if not already there.
