### PR TITLE
Remove useless code

### DIFF
--- a/public/js/cssarrowplease.js
+++ b/public/js/cssarrowplease.js
@@ -86,24 +86,6 @@ Arrow.prototype = {
   },
 
   /**
-  @method hexToRGB
-  @description
-    returns an rgb color from an hex color
-  @returns {Array}
-  **/
-  hexToRGB: function (h) {
-    if ( typeof h !== 'string' || !h.match(/^#([0-9A-F]{3}$)|([0-9A-F]{6}$)/i) ) return [0, 0, 0];
-    else if ( h.match(/^(#[0-9a-f]{3})$/i) ) h = '#' + h[1] + h[1] + h[2] + h[2] + h[3] + h[3];
-    var rgb = [],
-        i = 1;
-
-    for(; i < 6; i+=2) {
-      rgb.push(parseInt(h.substring(i, i + 2), 16));
-    }
-    return rgb;
-  },
-
-  /**
   @method _baseCSS
   @description generates the base css
   @returns {String} css
@@ -168,7 +150,6 @@ Arrow.prototype = {
     color = this._sanitizeHexColors(color);
     var pos         = this.get('position'),
         iPos        = this.invertedPosition(),
-        rgbColor    = this.hexToRGB(color),
         borderWidth = this.get('borderWidth'),
         css         = "";
 
@@ -176,7 +157,6 @@ Arrow.prototype = {
 
     if(borderWidth > 0) css += '.arrow_box:' + layer + ' {\n';
 
-    css += '\tborder-color: rgba(' + rgbColor.join(', ') + ', 0);\n';
     css += '\tborder-' + iPos + '-color: ' + color + ';\n';
     css += '\tborder-width: ' + size + 'px;\n';
 


### PR DESCRIPTION
The border color is already set by the `border: solid transparent;` and changed by `border-side-color`.
There is not reason to set it to transparent again.
